### PR TITLE
Normalize params of Structure Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### VERSION 0.6.1
+
+* deprecations
+  * Structure validation rules, MinColumn, MaxColumn are replaced by :min_columns, :max_columns
+
 ### VERSION 0.6.0
 
 * backwards incompatible changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    csv2hash (0.6.0)
+    csv2hash (0.6.1)
       activesupport (~> 4.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Collection validation sample:
 ### Structure validation rules
 
 You may want to validate some structure, like min or max number of columns, definition accepts structure_rules as a key for the third parameter.
-Current validations are: MinColumn, MaxColumn
+Current validations are: :min_columns, :max_columns
 
 ```
   class MyParser
@@ -224,7 +224,7 @@ Current validations are: MinColumn, MaxColumn
       Main.generate_definition :my_defintion do
         set_type { Definition::COLLECTION }
         set_header_size { 1 }
-        set_structure_rules {{ 'MinColumns' => 2, 'MaxColumns' => 3 }}
+        set_structure_rules {{ min_columns: 2, max_columns: 3 }}
           mapping do
             cell position: 0, key: 'nickname'
             cell position: 1, key: 'first_name'

--- a/lib/csv2hash/structure_validator.rb
+++ b/lib/csv2hash/structure_validator.rb
@@ -1,31 +1,45 @@
-# require 'active_support/core_ext'
+require 'active_support/core_ext'
 
-module Csv2hash::StructureValidator
-  class ValidationError < StandardError ; end
+require_relative 'structure_validator/deprecation'
 
-  def validate_structure!
-    # binding.pry
-    definition.structure_rules.each do |rule, options|
+module Csv2hash
+  module StructureValidator
+    include Deprecation
+
+    class ValidationError < StandardError ; end
+
+    MAX_COLUMN = 'max_columns'.freeze
+    MIN_COLUMN = 'min_columns'.freeze
+    RULES_NAME = [ MIN_COLUMN, MAX_COLUMN ]
+
+    def validate_structure!
+      definition.structure_rules.each do |rule, options|
+        begin
+          rule_instance(rule, options).validate! data_source
+        rescue => e
+          self.errors << { y: nil, x: nil, message: e.message, key: nil }
+          raise if break_on_failure
+        end
+      end
+    end
+
+    def rule_instance rule, options
+      _rule = check_params rule
       begin
-        rule_instance(rule, options).validate! data_source
-      rescue => e
-        self.errors << { y: nil, x: nil, message: e.message, key: nil }
-        raise if break_on_failure
+        StructureValidator.const_get(_rule.camelize).new(options)
+      rescue NameError => e
+        raise "Structure rule #{rule} unknow, please use one of these #{RULES_NAME}"
       end
     end
-  end
 
-  def rule_instance rule, options
-    Csv2hash::StructureValidator.const_get(rule).new(options)
-    # 'min_columns'.camelize.constantize.new
-  end
-
-  module Validator
-    def validate! source
-      source.index { |line| validate_line line }.tap do |line|
-        raise Csv2hash::StructureValidator::ValidationError, error_message(line) unless line.nil?
+    module Validator
+      def validate! source
+        source.index { |line| validate_line line }.tap do |line|
+          raise ValidationError, error_message(line) unless line.nil?
+        end
+        true
       end
-      true
     end
+
   end
 end

--- a/lib/csv2hash/structure_validator/deprecation.rb
+++ b/lib/csv2hash/structure_validator/deprecation.rb
@@ -1,0 +1,21 @@
+module Csv2hash
+  module StructureValidator
+    module Deprecation
+
+      OLD_MAX_COLUMN = 'MaxColumns'.freeze
+      OLD_MIN_COLUMN = 'MinColumns'.freeze
+      OLD_RULES_NAME = [ OLD_MIN_COLUMN, OLD_MAX_COLUMN ]
+      NEW_SYNTAX = { OLD_MIN_COLUMN => 'min_columns', OLD_MAX_COLUMN => 'max_columns' }
+
+      def check_params rule
+        if OLD_RULES_NAME.include? rule
+          warn "[DEPRECATION]: `#{rule}` is deprecated.  Please use `#{NEW_SYNTAX[rule]}` instead."
+          NEW_SYNTAX[rule]
+        else
+          rule.to_s
+        end
+      end
+
+    end
+  end
+end

--- a/lib/csv2hash/structure_validator/max_columns.rb
+++ b/lib/csv2hash/structure_validator/max_columns.rb
@@ -1,18 +1,20 @@
-module Csv2hash::StructureValidator
-  class MaxColumns
+module Csv2hash
+  module StructureValidator
+    class MaxColumns
 
-    include Csv2hash::StructureValidator::Validator
+      include Validator
 
-    def initialize max_size
-      @max_size = max_size
-    end
+      def initialize max_size
+        @max_size = max_size
+      end
 
-    def validate_line line
-      line.size > @max_size
-    end
+      def validate_line line
+        line.size > @max_size
+      end
 
-    def error_message line
-      "Too many columns (max. #{@max_size}) on line #{line}"
+      def error_message line
+        "Too many columns (max. #{@max_size}) on line #{line}"
+      end
     end
   end
 end

--- a/lib/csv2hash/structure_validator/min_columns.rb
+++ b/lib/csv2hash/structure_validator/min_columns.rb
@@ -1,18 +1,20 @@
-module Csv2hash::StructureValidator
-  class MinColumns
+module Csv2hash
+  module StructureValidator
+    class MinColumns
 
-    include Csv2hash::StructureValidator::Validator
+      include Validator
 
-    def initialize min_size
-      @min_size = min_size
-    end
+      def initialize min_size
+        @min_size = min_size
+      end
 
-    def validate_line line
-      line.size < @min_size
-    end
+      def validate_line line
+        line.size < @min_size
+      end
 
-    def error_message line
-      "Not enough columns (min. #{@min_size}) on line #{line}"
+      def error_message line
+        "Not enough columns (min. #{@min_size}) on line #{line}"
+      end
     end
   end
 end

--- a/lib/csv2hash/version.rb
+++ b/lib/csv2hash/version.rb
@@ -1,3 +1,3 @@
 module Csv2hash
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/csv2hash/structure_validator_spec.rb
+++ b/spec/csv2hash/structure_validator_spec.rb
@@ -18,7 +18,7 @@ module Csv2hash
 
     context 'the csv with errors' do
       before do
-        allow(definition).to receive(:structure_rules) {{ 'MaxColumns' => 2 }}
+        allow(definition).to receive(:structure_rules) {{ max_columns: 2 }}
         subject.parse
       end
       let(:data_source) do
@@ -30,13 +30,14 @@ module Csv2hash
 
       its(:csv_with_errors) { should be_kind_of CsvArray }
       it "adds structure error in first cell" do
+
         expect(subject.csv_with_errors.first[:message]).to eq 'Too many columns (max. 2) on line 1'
       end
     end
 
     context '#MaxColumns'  do
       before do
-        allow(definition).to receive(:structure_rules) {{ 'MaxColumns' => 2 }}
+        allow(definition).to receive(:structure_rules) {{ max_columns: 2 }}
         allow(subject).to receive(:break_on_failure) { true }
       end
 
@@ -62,7 +63,7 @@ module Csv2hash
 
     context '#MinColumns'  do
       before do
-        allow(definition).to receive(:structure_rules) {{ 'MinColumns' => 2 }}
+        allow(definition).to receive(:structure_rules) {{ min_columns: 2 }}
         allow(subject).to receive(:break_on_failure) { true }
       end
 


### PR DESCRIPTION
### VERSION 0.6.1
- deprecations
  - Structure validation rules, MinColumn, MaxColumn are replaced by :min_columns, :max_columns
