### PR TITLE
add ERB interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### VERSION 0.6.4
+
+* feature
+  * make configuration file can be writing with ERB interpolation.
+
 ### VERSION 0.6.3
 
 * refactoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    csv2hash (0.6.3)
+    csv2hash (0.6.4)
       activesupport (~> 4.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ rules:
   - { position: [2,1], key: 'first_name' }
 ```
 
+You can write ERB file, should be named with following convention ```<file name>.erb.yml```
+
 # Changes
 
 please refere to [CHANGELOG.md](https://github.com/FinalCAD/csv2hash/blob/master/CHANGELOG.md) doc

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,12 @@
 # Upgrading
 
+# Upgrading from 0.6.3 to 0.6.4
+
+nothing
+
 # Upgrading from 0.6.2 to 0.6.3
+
+nothing
 
 # Upgrading from 0.6.1 to 0.6.2
 

--- a/config/rules.erb.yml
+++ b/config/rules.erb.yml
@@ -1,0 +1,7 @@
+name: 'example'
+mapping: 'mapping'
+header_size: <%= 3 - 1 %>
+structure_rules: { max_columns: 20 }
+rules:
+  - { position: [1,1], key: 'first_name' }
+  - { position: [2,1], key: 'first_name' }

--- a/lib/csv2hash/version.rb
+++ b/lib/csv2hash/version.rb
@@ -1,3 +1,3 @@
 module Csv2hash
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end

--- a/lib/csv2hash/yaml_loader.rb
+++ b/lib/csv2hash/yaml_loader.rb
@@ -8,7 +8,7 @@ module Csv2hash
     attr_accessor :definition
 
     def initialize file
-      @conf = YAML.load_file(file)
+      @conf = load_config_file file
       self.conf.deep_symbolize_keys!
     end
 
@@ -29,5 +29,16 @@ module Csv2hash
 
       Main[self.conf.fetch(:name)] = self.definition
     end
+
+    private
+
+    def load_config_file file
+      if file.to_s =~ /(?<ext>\.erb\.)/
+        YAML.load(ERB.new(File.read(file)).result)
+      else
+        YAML.load_file(file)
+      end
+    end
+
   end
 end

--- a/spec/csv2hash/yaml_loader_spec.rb
+++ b/spec/csv2hash/yaml_loader_spec.rb
@@ -2,18 +2,25 @@ require 'spec_helper'
 
 module Csv2hash
   describe YamlLoader do
-    let(:config_file) { 'config/rules.yml' }
+    subject { YamlLoader.new config_file }
+    before  { subject.load! }
 
-    subject do
-      YamlLoader.new config_file
+    context 'yml' do
+      let(:config_file) { 'config/rules.erb.yml' }
+
+      specify do
+        expect(subject.definition.name).to eql('example')
+        expect(subject.definition.header_size).to eql(2)
+      end
     end
 
-    before do
-      subject.load!
-    end
+    context 'erb' do
+      let(:config_file) { 'config/rules.yml' }
 
-    specify do
-      expect(subject.definition.name).to eql('example')
+      specify do
+        expect(subject.definition.name).to eql('example')
+        expect(subject.definition.header_size).to eql(2)
+      end
     end
 
   end


### PR DESCRIPTION
### VERSION 0.6.4
- feature
  - make configuration file can be writing with ERB interpolation.

You can write ERB file, should be named with following convention `<file name>.erb.yml`
