### PR TITLE
Fix bug and add case sensitive values

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ cell name: 'aswering', type: 'string', values: ['yes', 'no'], position: [0,0]
 cell name: 'aswering', values: ['yes', 'no'], position: [0,0]
 ```
 
+By default values are case sensitive but if you want the value to be a string that can be either 'yes' or 'no' case insentive ('Yes', 'YES', 'No', 'NO') you can define the following validation rule:
+
+```
+cell name: 'aswering', values: ['yes', 'no'], case_sensitive_values: false, position: [0,0]
+```
+
 You can define you own message but default message is 'undefined :key on :position'
 
 ```
@@ -155,6 +161,7 @@ All remaining keys are optionals:
 * mappable:    true
 * type:        'string'
 * values:      nil
+* case_sensitive_values: true
 * nested:      nil
 * allow_blank: false
 * extra_validator: nil

--- a/lib/csv2hash/definition.rb
+++ b/lib/csv2hash/definition.rb
@@ -50,12 +50,13 @@ module Csv2hash
         cell.rules.fetch(:position)
         default_position cell
         default_message cell
-        cell.rules.merge! mappable:    true    unless cell.rules.has_key? :mappable
-        cell.rules.merge! type:       'string' unless cell.rules.has_key? :type
-        cell.rules.merge! values:      nil     unless cell.rules.has_key? :values
-        cell.rules.merge! nested:      nil     unless cell.rules.has_key? :nested
-        cell.rules.merge! allow_blank: false   unless cell.rules.has_key? :allow_blank
-        cell.rules.merge! extra_validator: nil unless cell.rules.has_key? :extra_validator
+        cell.rules.merge! mappable:               true  unless cell.rules.has_key? :mappable
+        cell.rules.merge! type:                'string' unless cell.rules.has_key? :type
+        cell.rules.merge! values:                  nil  unless cell.rules.has_key? :values
+        cell.rules.merge! case_sensitive_values:  true  unless cell.rules.has_key? :case_sensitive_values
+        cell.rules.merge! nested:                  nil  unless cell.rules.has_key? :nested
+        cell.rules.merge! allow_blank:           false  unless cell.rules.has_key? :allow_blank
+        cell.rules.merge! extra_validator:         nil  unless cell.rules.has_key? :extra_validator
       end
     end
 

--- a/lib/csv2hash/validator.rb
+++ b/lib/csv2hash/validator.rb
@@ -29,8 +29,7 @@ module Csv2hash
           verify_extra_validator! cell, value
         else
           if has_valid_values? cell, value
-            values = cell.rules.fetch(:values)
-            verify_valid_values! values, value
+            verify_valid_values! cell, value
           end
         end
       rescue => e
@@ -66,13 +65,19 @@ module Csv2hash
       value.present? && cell.rules.fetch(:values)
     end
 
-    def verify_valid_values! values, value
+    def verify_valid_values! cell, value
+      values = cell.rules.fetch(:values)
       if values.class == Range
         raise unless values.include?(value.to_f)
       else
-        raise unless values.include?(value)
+        case_sensitive_values = cell.rules.fetch(:case_sensitive_values)
+        raise unless valid_values_include? values, value, case_sensitive_values
       end
     end
+
+    def valid_values_include? values, value, case_sensitive
+      case_sensitive ? values.include?(value) : values.any?{ |v| v.casecmp(value)==0 }
+    end 
 
     def find_or_remove_dynamic_fields_on_mapping!
       cells = definition.cells.dup

--- a/spec/csv2hash/definition_spec.rb
+++ b/spec/csv2hash/definition_spec.rb
@@ -64,6 +64,7 @@ module Csv2hash
           mappable: true,
           type: 'string',
           values: nil,
+          case_sensitive_values: true,
           nested: nil,
           allow_blank: false,
           extra_validator: nil })

--- a/spec/csv2hash/validator_spec.rb
+++ b/spec/csv2hash/validator_spec.rb
@@ -38,21 +38,23 @@ module Csv2hash
     end
 
     describe '#validate_cell' do
-      let(:x)           { 0 }
-      let(:y)           { 0 }
-      let(:allow_blank) { false }
-      let(:values)      { nil } 
-      let(:data_source) { [ ['John Doe'] ]}
-      let(:rules)       { { position: [x, y],
-                            key: 'name',
-                            message: 'undefined :key on :position',
-                            mappable: true,
-                            type: 'string',
-                            values: values,
-                            nested: nil,
-                            allow_blank: allow_blank,
-                            extra_validator: nil }}
-      let(:cell)        { Cell.new(rules) }
+      let(:x)                     { 0 }
+      let(:y)                     { 0 }
+      let(:allow_blank)           { false }
+      let(:values)                { nil } 
+      let(:case_sensitive_values) { false }
+      let(:data_source)           { [ ['John Doe'] ]}
+      let(:rules)                 { { position: [x, y],
+                                    key: 'name',
+                                    message: 'undefined :key on :position',
+                                    mappable: true,
+                                    type: 'string',
+                                    values: values,
+                                    case_sensitive_values: case_sensitive_values,
+                                    nested: nil,
+                                    allow_blank: allow_blank,
+                                    extra_validator: nil }}
+      let(:cell)                  { Cell.new(rules) }
       
       before do 
         allow(subject).to receive(:break_on_failure) { true }
@@ -63,22 +65,41 @@ module Csv2hash
         it{ expect{ subject.send(:validate_cell, x, y, cell) }.to_not raise_error }
       end
 
-      context 'when allow_blank is false and data source value is blank' do
+      context 'when position in data source is blank' do
         let(:data_source) { [ [''] ]}
-        let(:allow_blank) { false }
-        it{ expect{ subject.send(:validate_cell, x, y, cell) }.to raise_error 'undefined :name on [0, 0]' }        
-      end
+        
+        context 'and allow_blank is false' do 
+          let(:allow_blank) { false }
+          it{ expect{ subject.send(:validate_cell, x, y, cell) }.to raise_error 'undefined :name on [0, 0]' }
+        end
 
-      context 'when allow_blank is true and data source value is blank' do
-        let(:data_source) { [ [''] ]}
-        let(:allow_blank) { true }
-        it{ expect{ subject.send(:validate_cell, x, y, cell) }.to_not raise_error }
-
-        context 'and values are not nil' do
-          let(:values) { ['yes', 'no'] }
+        context 'and allow_blank is true' do 
+          let(:allow_blank) { true }
           it{ expect{ subject.send(:validate_cell, x, y, cell) }.to_not raise_error }
-        end        
-      end        
+
+          context 'and values are not nil' do
+            let(:values) { ['yes', 'no'] }
+            it{ expect{ subject.send(:validate_cell, x, y, cell) }.to_not raise_error }
+          end  
+        end              
+      end 
+
+      context 'when values are not nil' do
+        let(:values)      { ['john doe', 'jane doe'] }
+        let(:data_source) { [ ['John Doe'] ]} 
+        
+        context 'and case_sensitive_values is true' do
+          let(:case_sensitive_values) { true }
+
+          it{ expect{ subject.send(:validate_cell, x, y, cell) }.to raise_error }
+        end
+
+        context 'and case_sensitive_values is false' do
+          let(:case_sensitive_values) { false }
+          
+          it{ expect{ subject.send(:validate_cell, x, y, cell) }.to_not raise_error }
+        end
+      end     
     end
   end
 end


### PR DESCRIPTION
- Fix bug when setting values to a cell and the value is blank it returns an error even when allow_blank is true
- Adds case_sensitive_values:
  When adding values rule to a cell, by default it match the value with the values rule in case sensitive way. But it can be specified to do it in a case insensitive way. 
