### PR TITLE
adds error handling for invalid file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### VERSION 0.7.7
+
+* enhancements
+  * prevent to pass wrong file to CSV adapter
+
 ### VERSION 0.7.6
 
 * bug fix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    csv2hash (0.7.6)
+    csv2hash (0.7.7)
       activesupport (~> 4.1)
 
 GEM

--- a/lib/csv2hash.rb
+++ b/lib/csv2hash.rb
@@ -19,6 +19,7 @@ require_relative 'csv2hash/extra_validator'
 require_relative 'csv2hash/adapters/base'
 require_relative 'csv2hash/yaml_loader'
 require_relative 'csv2hash/coercers/type_coercer'
+require_relative 'csv2hash/errors'
 
 require 'csv2hash/railtie' if defined?(Rails)
 

--- a/lib/csv2hash/adapters/csv_adapter.rb
+++ b/lib/csv2hash/adapters/csv_adapter.rb
@@ -13,9 +13,14 @@ module Csv2hash
       end
 
       def source
+        check_file!
         CSV.read self.file_path
-      rescue ::ArgumentError
-        raise ::Csv2hash::InvalidFile
+      end
+
+      private
+
+      def check_file!
+        raise ::Csv2hash::InvalidFile unless File.extname(self.file_path) =~ /csv/i
       end
 
     end

--- a/lib/csv2hash/adapters/csv_adapter.rb
+++ b/lib/csv2hash/adapters/csv_adapter.rb
@@ -14,6 +14,8 @@ module Csv2hash
 
       def source
         CSV.read self.file_path
+      rescue ::ArgumentError
+        raise ::Csv2hash::InvalidFile
       end
 
     end

--- a/lib/csv2hash/errors.rb
+++ b/lib/csv2hash/errors.rb
@@ -1,0 +1,7 @@
+module Csv2hash
+  class InvalidFile < ArgumentError
+    def initialize
+      super("Provided file has wrong format.")
+    end
+  end
+end

--- a/lib/csv2hash/version.rb
+++ b/lib/csv2hash/version.rb
@@ -1,3 +1,3 @@
 module Csv2hash
-  VERSION = '0.7.6'
+  VERSION = '0.7.7'
 end


### PR DESCRIPTION
Csv2hash was responding with:
Argum​entEr​ror: ​inval​id by​te se​quenc​e in ​UTF-8

when it got a zip file instead of a csv.

Error was raised from line:
https://github.com/FinalCAD/csv2hash/blob/master/lib/csv2hash/adapters/csv_adapter.rb#L16
